### PR TITLE
deps: remove owner from AsyncTCP dependency and allow >=2.0.0

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESPAsyncMQTTBroker",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "An asynchronous MQTT broker for ESP32",
   "keywords": "mqtt, broker, async, esp32",
   "repository": {
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "ESP32Async/AsyncTCP": "^2.0.0"
+    "AsyncTCP": ">=2.0.0"
   },
   "frameworks": "arduino",
   "platforms": "espressif32"


### PR DESCRIPTION
This PR adjusts the PlatformIO library manifest to avoid the warning about a pinned owner for AsyncTCP and to support newer AsyncTCP versions:

- Change dependency from "ESP32Async/AsyncTCP": "^2.0.0" to "AsyncTCP": ">=2.0.0"
- Bump library version to 1.5.2

Why:
- PlatformIO warns when a dependency references an owner that doesn't match the installed package source
- Using the registry package name without owner eliminates the cosmetic warning and still resolves to the correct package on espressif32

Tested by: using this branch in a PlatformIO project via lib_deps "https://github.com/parip69/ESPAsyncMQTTBroker.git#fix/deps-async-tcp-no-owner" — build succeeds and the warning disappears.

Thanks!