### PR TITLE
feat: Make logging configurable via a boolean flag

### DIFF
--- a/examples/BasicBroker/main.cpp
+++ b/examples/BasicBroker/main.cpp
@@ -1,10 +1,26 @@
 #include <ESPAsyncMQTTBroker.h>
+#if defined(ESP8266)
+#include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
+#endif
 
 ESPAsyncMQTTBroker mqtt;
 
 void setup() {
   Serial.begin(115200);
   WiFi.begin("SSID", "PASSWORT");
+
+  // Create a configuration object
+  ESPAsyncMQTTBrokerConfig config;
+
+  // Set the log flag to false to disable logging
+  // Default is true
+  config.log = false;
+
+  // Set the configuration
+  mqtt.setConfig(config);
+
   mqtt.begin();
 }
 

--- a/src/ESPAsyncMQTTBroker.cpp
+++ b/src/ESPAsyncMQTTBroker.cpp
@@ -116,6 +116,11 @@ void ESPAsyncMQTTBroker::checkTimeouts()
 void ESPAsyncMQTTBroker::setConfig(const ESPAsyncMQTTBrokerConfig &config)
 {
     brokerConfig = config;
+    if (brokerConfig.log) {
+        setDebugLevel(DEBUG_INFO);
+    } else {
+        setDebugLevel(DEBUG_NONE);
+    }
     logMessage(DEBUG_INFO, "MQTT-Broker Configuration:");
     logMessage(DEBUG_INFO, "   Username: %s", (brokerConfig.username.isEmpty() ? "[empty]" : brokerConfig.username.c_str()));
     logMessage(DEBUG_INFO, "   Password: %s", (brokerConfig.password.isEmpty() ? "[empty]" : "[set]"));

--- a/src/ESPAsyncMQTTBroker.h
+++ b/src/ESPAsyncMQTTBroker.h
@@ -107,6 +107,7 @@ struct ESPAsyncMQTTBrokerConfig
     String username = "";
     String password = "";
     bool ignoreLoopDeliver = false;
+    bool log = true;
 };
 
 struct IncomingQoS2Message


### PR DESCRIPTION
Adds a `log` boolean flag to the `ESPAsyncMQTTBrokerConfig` struct, allowing users to enable or disable logging from the main application.

- The `log` flag defaults to `true` to maintain backward compatibility.
- The `setConfig` method now sets the debug level to `DEBUG_NONE` if `log` is false, and `DEBUG_INFO` if `log` is true.
- The `BasicBroker` example has been updated to demonstrate how to use this new feature to disable logging.